### PR TITLE
Fix path to GitHub repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use this code you will need to have your own Vercel deployment. This requires
 
 You can also simply click the button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/mraible/okta-hooks)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/import/project?template=https://github.com/omgitstom/okta-hooks)
 
 ### Steps
 

--- a/okta.json
+++ b/okta.json
@@ -1,6 +1,6 @@
 {
- "name": "Okta Inline Hooks with Zeit Now",
- "description": "This repo Zeit Now to quickly configure a serverless function that can responsd to a Okta Inline Hook.  You can use query parameters to modify responses for testing",
+ "name": "Okta Inline Hooks with Vercel",
+ "description": "This repo uses Vercel to quickly configure a serverless function that can responsd to a Okta Inline Hook.  You can use query parameters to modify responses for testing.",
  "categories": [
     "hooks"
   ]


### PR DESCRIPTION
I tried the button with this (updated) URL and it worked.

Another improvement we could make would be to update `src/App.js` to look for environment variables (these can be set as part of the Vercel import process) for Okta settings.

Proof at https://okta-fun.vercel.app/. I did have to update the redirect URIs on Okta for this new domain.